### PR TITLE
🐛 (Makefile): build documents twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,16 @@ REQMANUAL:=
 all: quickstart.pdf customimages.pdf manual.pdf
 
 quickstart.pdf: quickstart.tex $(REQQUICK)
-	pdflatex `basename "$@" .pdf`.tex 
+	pdflatex `basename "$@" .pdf`.tex
+	pdflatex `basename "$@" .pdf`.tex
 
 customimages.pdf: customimages.tex $(REQCUSTOM)
-	pdflatex `basename "$@" .pdf`.tex 
+	pdflatex `basename "$@" .pdf`.tex
+	pdflatex `basename "$@" .pdf`.tex
 
 manual.pdf: manual.tex $(REQMANUAL)
-	pdflatex `basename "$@" .pdf`.tex 
+	pdflatex `basename "$@" .pdf`.tex
+	pdflatex `basename "$@" .pdf`.tex
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This pr modifies the Makefile by adding a second pdflatex command to each target (`quickstart.pdf`, `customimages.pdf`, and `manual.pdf`). Running `pdflatex` twice it ensures that all references and figures are properly resolved. This fix the empty Table of Content section.