### PR TITLE
✨ (manual): update page margins

### DIFF
--- a/manual.tex
+++ b/manual.tex
@@ -8,6 +8,7 @@
 % Patch \part to reset section counter automatically
 \pretocmd{\part}{\setcounter{section}{0}}{}{}
 
+\usepackage[margin=.6in]{geometry}
 % Document starts
 \begin{document}
 


### PR DESCRIPTION
Changed page margin to `.6 inc` in order to have less pages with more text for single page.
This should make more readable the document.


|_Before_|_After_|
| -------| ------|
|![image](https://github.com/user-attachments/assets/417bff3f-2b75-4da4-a6ac-c48a5b1d8fe0)| ![image](https://github.com/user-attachments/assets/e731c2dd-32ea-4a82-a955-f5bb597d0da8)|